### PR TITLE
Fix userdata upvals for c funcs causing errors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.1.5
 Date: ????
-  Changes:
+  Bugfixes:
+    - Fixed function capture error about userdata upvalues for c functions like math.random
 ---------------------------------------------------------------------------------------------------
 Version: 1.1.4
 Date: 2022-06-03

--- a/scenario-scripts/tests/test_funccapture.lua
+++ b/scenario-scripts/tests/test_funccapture.lua
@@ -129,6 +129,23 @@ add_test{
 }
 
 add_test{
+  name = "c function with userdata upvals upval",
+  run = function()
+    -- arrange
+    local random = math.random -- math.random has 2 userdata upvals
+    local function func()
+      return random
+    end
+    -- act
+    local captured = capture(func)
+    local loaded = assert(load(captured))
+    local result = loaded()
+    -- assert
+    assert_equals(result, random)
+  end,
+}
+
+add_test{
   name = "invalid c function upval",
   run = function()
     -- arrange

--- a/scenario-scripts/tests/test_funccapture.lua
+++ b/scenario-scripts/tests/test_funccapture.lua
@@ -132,7 +132,7 @@ add_test{
   name = "c function with userdata upvals upval",
   run = function()
     -- arrange
-    local random = math.random -- math.random has 2 userdata upvals
+    local random = math.random -- math.random has 2 userdata upvals, which should be ignored
     local function func()
       return random
     end
@@ -141,7 +141,7 @@ add_test{
     local loaded = assert(load(captured))
     local result = loaded()
     -- assert
-    assert_equals(result, random)
+    assert_equals(math.random, result)
   end,
 }
 


### PR DESCRIPTION
It was finding all upvalues first, then checking for c functions later. Moving the check for c functions earlier fixes this.